### PR TITLE
Implementar carga de imágenes en formulario de libros con Supabase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "15.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "uuid": "^11.1.0",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -20,6 +21,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/uuid": "^10.0.0",
         "eslint": "^9",
         "eslint-config-next": "15.3.2",
         "typescript": "^5"
@@ -1122,6 +1124,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -5480,6 +5489,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "15.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "uuid": "^11.1.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {
@@ -21,6 +22,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/uuid": "^10.0.0",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
     "typescript": "^5"

--- a/src/app/books/add/AddBookForm.tsx
+++ b/src/app/books/add/AddBookForm.tsx
@@ -32,6 +32,7 @@ type FormState = {
 export default function AddBookForm() {
   const router = useRouter()
   const [selectedCategories, setSelectedCategories] = useState<string[]>([])
+  const [imagePreview, setImagePreview] = useState<string | null>(null)
   
   // Estado del formulario
   const [formState, setFormState] = useState<FormState>({
@@ -47,6 +48,54 @@ export default function AddBookForm() {
       router.refresh();
     }
   }, [formState.success, router]);
+
+  // Manejador para previsualizar la imagen seleccionada
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      // Validar el tipo de archivo
+      if (!file.type.startsWith('image/')) {
+        setFormState({
+          error: 'El archivo seleccionado debe ser una imagen',
+          success: false,
+          data: null
+        });
+        e.target.value = '';
+        setImagePreview(null);
+        return;
+      }
+      
+      // Validar el tamaño (máximo 2MB)
+      if (file.size > 2 * 1024 * 1024) {
+        setFormState({
+          error: 'La imagen no debe superar los 2MB',
+          success: false,
+          data: null
+        });
+        e.target.value = '';
+        setImagePreview(null);
+        return;
+      }
+      
+      // Crear URL para previsualización
+      const reader = new FileReader();
+      reader.onload = () => {
+        setImagePreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+      
+      // Limpiar error si existe
+      if (formState.error) {
+        setFormState({
+          error: null,
+          success: false,
+          data: null
+        });
+      }
+    } else {
+      setImagePreview(null);
+    }
+  };
 
   // Función para manejar la acción del formulario con categorías
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -119,15 +168,31 @@ export default function AddBookForm() {
         </div>
         
         <div className="form-group">
-          <label className="form-label" htmlFor="cover_url">URL de Portada</label>
+          <label className="form-label" htmlFor="cover_image">Imagen de Portada</label>
           <input
-            type="url"
-            id="cover_url"
-            name="cover_url"
+            type="file"
+            id="cover_image"
+            name="cover_image"
             className="form-input"
-            placeholder="https://ejemplo.com/imagen.jpg"
+            accept="image/*"
+            onChange={handleImageChange}
             required
           />
+          {imagePreview && (
+            <div className="image-preview">
+              <img 
+                src={imagePreview} 
+                alt="Vista previa" 
+                style={{ 
+                  maxWidth: '100%', 
+                  maxHeight: '200px', 
+                  marginTop: '10px',
+                  borderRadius: '4px'
+                }} 
+              />
+            </div>
+          )}
+          <p className="input-help">Formato recomendado: JPG o PNG. Máximo 2MB.</p>
         </div>
 
         <div className="form-group">

--- a/src/app/books/schemas/book.schema.ts
+++ b/src/app/books/schemas/book.schema.ts
@@ -5,7 +5,7 @@ export const BookSchema = z.object({
   title: z.string().min(1, 'El título es requerido'),
   author: z.string().min(1, 'El autor es requerido'),
   description: z.string().optional(),
-  cover_url: z.string().url('La URL de la portada no es válida'),
+  cover_url: z.string().url('La URL de la portada no es válida').optional(),
   link: z.string().url('El enlace del libro no es válido'),
   access: z.enum(['free', 'paid'], {
     errorMap: () => ({ message: 'El acceso debe ser "free" o "paid"' })
@@ -23,15 +23,16 @@ export function validateBook(formData: FormData): ValidationResult {
     const title = formData.get('title')
     const author = formData.get('author')
     const description = formData.get('description')
-    const cover_url = formData.get('cover_url')
     const link = formData.get('link')
     const access = formData.get('access')
+
+    // Ya no es necesario buscar cover_url, ya que ahora manejamos un archivo
+    // La URL real se generará después de cargar el archivo a Supabase Storage
 
     const result = BookSchema.safeParse({
       title,
       author,
       description: description || undefined,
-      cover_url,
       link,
       access,
     })

--- a/src/app/books/services/storage.service.ts
+++ b/src/app/books/services/storage.service.ts
@@ -1,0 +1,117 @@
+import { createServerSupabaseClient } from '@/app/ssr/client';
+import { v4 as uuidv4 } from 'uuid';
+
+const BUCKET_NAME = 'books-covers';
+
+// Tipo para la respuesta de carga de archivo
+type UploadResponse = {
+  url: string | null;
+  error: Error | null;
+};
+
+/**
+ * Sube una imagen de portada a Supabase Storage
+ * @param file Archivo de imagen a subir
+ * @param userId ID del usuario que sube la imagen
+ * @returns Objeto con la URL pública de la imagen
+ */
+export async function uploadBookCover(
+  file: File,
+  userId: string
+): Promise<UploadResponse> {
+  try {
+    // Verificar que el archivo es una imagen
+    if (!file.type.startsWith('image/')) {
+      throw new Error('El archivo debe ser una imagen');
+    }
+
+    // Limitar el tamaño a 2MB
+    if (file.size > 2 * 1024 * 1024) {
+      throw new Error('La imagen no debe superar los 2MB');
+    }
+
+    const supabase = createServerSupabaseClient();
+
+    // Verificar si el bucket existe, si no, crearlo
+    const { data: buckets } = await supabase.storage.listBuckets();
+    const bucketExists = buckets?.some(bucket => bucket.name === BUCKET_NAME);
+
+    if (!bucketExists) {
+      await supabase.storage.createBucket(BUCKET_NAME, {
+        public: true,
+        fileSizeLimit: 2 * 1024 * 1024, // 2MB
+      });
+    }
+
+    // Generar un nombre único para el archivo
+    const fileExtension = file.name.split('.').pop();
+    const fileName = `${userId}/${uuidv4()}.${fileExtension}`;
+
+    // Subir el archivo
+    const { error: uploadError } = await supabase.storage
+      .from(BUCKET_NAME)
+      .upload(fileName, file, {
+        cacheControl: '3600',
+        upsert: false,
+      });
+
+    if (uploadError) {
+      throw uploadError;
+    }
+
+    // Obtener la URL pública
+    const { data: publicUrlData } = supabase.storage
+      .from(BUCKET_NAME)
+      .getPublicUrl(fileName);
+
+    return {
+      url: publicUrlData.publicUrl,
+      error: null,
+    };
+  } catch (error) {
+    console.error('Error uploading book cover:', error);
+    return { url: null, error: error as Error };
+  }
+}
+
+/**
+ * Elimina una imagen de portada de Supabase Storage según la URL
+ * @param coverUrl URL pública de la imagen a eliminar
+ * @returns Objeto indicando si hubo error
+ */
+export async function deleteBookCover(coverUrl: string): Promise<{ error: Error | null }> {
+  try {
+    const supabase = createServerSupabaseClient();
+    
+    // Extraer la ruta del archivo de la URL
+    // Las URLs de Supabase Storage siguen este patrón:
+    // https://[project-ref].supabase.co/storage/v1/object/public/[bucket-name]/[file-path]
+    const urlObj = new URL(coverUrl);
+    const pathSegments = urlObj.pathname.split('/');
+    const bucketIndex = pathSegments.findIndex(segment => segment === BUCKET_NAME);
+    
+    if (bucketIndex === -1 || bucketIndex === pathSegments.length - 1) {
+      throw new Error('URL de imagen inválida');
+    }
+    
+    // Obtener la ruta relativa al bucket
+    const filePath = pathSegments.slice(bucketIndex + 1).join('/');
+    
+    if (!filePath) {
+      throw new Error('No se pudo determinar la ruta del archivo');
+    }
+
+    const { error } = await supabase.storage
+      .from(BUCKET_NAME)
+      .remove([filePath]);
+
+    if (error) {
+      throw error;
+    }
+
+    return { error: null };
+  } catch (error) {
+    console.error('Error deleting book cover:', error);
+    return { error: error as Error };
+  }
+} 


### PR DESCRIPTION
Se implementó la funcionalidad de carga de imágenes en el formulario de creación y edición de libros utilizando Supabase Storage. Ahora los usuarios pueden subir una imagen de portada que se almacenará en Supabase, y su URL se guardará junto con los datos del libro.

Cambios realizados
	•	Integración con Supabase Storage para manejo de archivos.
	•	Se añadió un campo de carga de imagen en el formulario de libros.
	•	Validación básica para asegurar que el archivo sea una imagen.
	•	Actualización del modelo y lógica de guardado para incluir la URL de la imagen.

Consideraciones
	•	Se debe contar con las variables de entorno de Supabase correctamente configuradas.
	•	Las imágenes se almacenan en el bucket libros (o el que se haya definido).

⸻